### PR TITLE
feat/update_install_via_gem_command

### DIFF
--- a/opsworks_commons/libraries/monkey_patch_rubygems_provider.rb
+++ b/opsworks_commons/libraries/monkey_patch_rubygems_provider.rb
@@ -1,0 +1,20 @@
+class Chef
+  class Provider
+    class Package
+      class Rubygems < Chef::Provider::Package
+        def install_via_gem_command(name, version)
+          if @new_resource.source =~ /\.gem$/i
+            name = @new_resource.source
+          else
+            src = @new_resource.source && "  --source=#{@new_resource.source} --source=http://rubygems.org"
+          end
+          if version
+            shell_out!("#{gem_binary_path} install #{name} -q -no-rdoc -no-ri -v \"#{version}\"#{src}#{opts}", :env=>nil)
+          else
+            shell_out!("#{gem_binary_path} install \"#{name}\" -q -no-rdoc -no-ri #{src}#{opts}", :env=>nil)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
chef 11.10 原本用 `--no-rdoc --no-ri` 選項安裝 gem
在 rubygem 3.0.8 會出錯造成開機器時不能裝 bundler

蓋掉 chef 的 `install_via_gem_command` 方法
把它改成用 `-no-rdoc -no-ri` 選項來安裝 bundler

已在測試機測試
`rubygem 3.0.8` 下新機器能部署成功
https://console.aws.amazon.com/opsworks/home?region=ap-northeast-1#/stack/d1e646f1-1eb3-497b-8da6-12c189d2e4b8/instances/47a3552a-8ee5-4455-b2ca-e70bb2341d42/log/87d43096-36b7-4405-8f5d-3e22a43a671e