### PR TITLE
feat: 新增 alb_support cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,6 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'alb_support', path: './alb_support'
 cookbook 'ruby', path: './ruby'
 cookbook 'deploy', path: './deploy'
 cookbook 'deploy_user', path: './deploy_user'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,4 +1,6 @@
 DEPENDENCIES
+  alb_support
+    path: alb_support
   deploy
     path: deploy
   deploy_user
@@ -15,6 +17,7 @@ DEPENDENCIES
     path: sidekiq
 
 GRAPH
+  alb_support (0.1.0)
   deploy (0.1.0)
   deploy_user (0.1.0)
   nginx (0.1.0)

--- a/alb_support/.delivery/project.toml
+++ b/alb_support/.delivery/project.toml
@@ -1,0 +1,32 @@
+# Delivery for Local Phases Execution
+#
+# This file allows you to execute test phases locally on a workstation or
+# in a CI pipeline. The delivery-cli will read this file and execute the
+# command(s) that are configured for each phase. You can customize them
+# by just modifying the phase key on this file.
+#
+# By default these phases are configured for Cookbook Workflow only
+#
+
+[local_phases]
+unit = "chef exec rspec spec/"
+lint = "chef exec cookstyle"
+# foodcritic has been deprecated in favor of cookstyle so we skip the syntax
+# phase now.
+syntax = "echo skipping syntax phase. Use lint phase instead."
+provision = "chef exec kitchen create"
+deploy = "chef exec kitchen converge"
+smoke = "chef exec kitchen verify"
+# The functional phase is optional, you can define it by uncommenting
+# the line below and running the command: `delivery local functional`
+# functional = ""
+cleanup = "chef exec kitchen destroy"
+
+# Remote project.toml file
+#
+# Instead of the local phases above, you may specify a remote URI location for
+# the `project.toml` file. This is useful for teams that wish to centrally
+# manage the behavior of the `delivery local` command across many different
+# projects.
+#
+# remote_file = "https://url/project.toml"

--- a/alb_support/.gitignore
+++ b/alb_support/.gitignore
@@ -1,0 +1,22 @@
+.vagrant
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+gems.locked
+bin/*
+.bundle/*
+
+# test kitchen
+.kitchen/
+kitchen.local.yml
+
+# Chef
+Berksfile.lock
+.zero-knife.rb
+Policyfile.lock.json

--- a/alb_support/Berksfile
+++ b/alb_support/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/alb_support/CHANGELOG.md
+++ b/alb_support/CHANGELOG.md
@@ -1,0 +1,10 @@
+# alb_support CHANGELOG
+
+This file is used to list changes made in each version of the alb_support cookbook.
+
+## 0.1.0
+
+Initial release.
+
+- change 0
+- change 1

--- a/alb_support/LICENSE
+++ b/alb_support/LICENSE
@@ -1,0 +1,3 @@
+Copyright 2020 BackerFounder
+
+All rights reserved, do not redistribute.

--- a/alb_support/README.md
+++ b/alb_support/README.md
@@ -1,0 +1,36 @@
+# ALB support
+
+## Setup
+
+1. Create Application Load Balancer & Target group.
+
+2. Create a IAM policy for register / deregister targets.
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Action": [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ],
+        "Resource": [
+          "arn:aws:elasticloadbalancing:....."
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": "elasticloadbalancing:DescribeTargetHealth",
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+
+3. Apply the policy to your EC2's role.
+
+4. Append target group arn to cookbook attribute `default[:alb_support][:target_group_arn]`.
+
+## References
+- [Use Application Load Balancers with your AWS OpsWorks Chef 12 Stacks - AWS Management & Governance Blog](https://aws.amazon.com/tw/blogs/mt/use-application-load-balancers-with-your-aws-opsworks-chef-12-stacks/)

--- a/alb_support/attributes/default.rb
+++ b/alb_support/attributes/default.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+default[:alb_support][:connection_draining_timeout] = 750
+default[:alb_support][:state_check_frequency] = 30
+default[:alb_support][:target_group_arn] = ''

--- a/alb_support/chefignore
+++ b/alb_support/chefignore
@@ -1,0 +1,115 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a Chef Infra Server or Supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+ehthumbs.db
+Icon?
+nohup.out
+Thumbs.db
+.envrc
+
+# EDITORS #
+###########
+.#*
+.project
+.settings
+*_flymake
+*_flymake.*
+*.bak
+*.sw[a-z]
+*.tmproj
+*~
+\#*
+REVISION
+TAGS*
+tmtags
+.vscode
+.editorconfig
+
+## COMPILED ##
+##############
+*.class
+*.com
+*.dll
+*.exe
+*.o
+*.pyc
+*.so
+*/rdoc/
+a.out
+mkmf.log
+
+# Testing #
+###########
+.circleci/*
+.codeclimate.yml
+.delivery/*
+.foodcritic
+.kitchen*
+.mdlrc
+.overcommit.yml
+.rspec
+.rubocop.yml
+.travis.yml
+.watchr
+.yamllint
+azure-pipelines.yml
+Dangerfile
+examples/*
+features/*
+Guardfile
+kitchen.yml*
+mlc_config.json
+Procfile
+Rakefile
+spec/*
+test/*
+
+# SCM #
+#######
+.git
+.gitattributes
+.gitconfig
+.github/*
+.gitignore
+.gitkeep
+.gitmodules
+.svn
+*/.bzr/*
+*/.git
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Bundler #
+###########
+vendor/*
+Gemfile
+Gemfile.lock
+
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
+# Documentation #
+#############
+CODE_OF_CONDUCT*
+CONTRIBUTING*
+documentation/*
+TESTING*
+UPGRADING*
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/alb_support/kitchen.yml
+++ b/alb_support/kitchen.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  product_version: 12
+  always_update_cookbooks: true
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: ubuntu-18.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[alb_support::deploy]
+      - recipe[alb_support::shutdown]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:

--- a/alb_support/metadata.rb
+++ b/alb_support/metadata.rb
@@ -1,0 +1,19 @@
+name 'alb_support'
+maintainer 'BackerFounder'
+maintainer_email 'it@backerfounder.com'
+license 'All Rights Reserved'
+description 'Add/Remove instances from AWS Application Load Balancer'
+version '0.1.0'
+chef_version '~> 12.14'
+
+# The `issues_url` points to the location where issues for this cookbook are
+# tracked.  A `View Issues` link will be displayed on this cookbook's page when
+# uploaded to a Supermarket.
+#
+# issues_url 'https://github.com/<insert_org_here>/ruby/issues'
+
+# The `source_url` points to the development repository for this cookbook.  A
+# `View Source` link will be displayed on this cookbook's page when uploaded to
+# a Supermarket.
+#
+# source_url 'https://github.com/<insert_org_here>/ruby'

--- a/alb_support/recipes/deploy.rb
+++ b/alb_support/recipes/deploy.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook:: alb_support
+# Recipe:: deploy
+#
+# Copyright:: 2020, BackerFounder, All Rights Reserved.
+
+stack = search("aws_opsworks_stack").first
+instance = search("aws_opsworks_instance", "self:true").first
+
+stack_region = stack[:region]
+ec2_instance_id = instance[:ec2_instance_id]
+target_group_arn = node[:alb_support][:target_group_arn]
+
+chef_gem "aws-sdk-core" do
+  version "~> 2.6"
+  action :install
+end
+
+ruby_block "attach to ALB" do
+  block do
+    require "aws-sdk-core"
+
+    Chef::Log.info("Creating ELB client in region #{stack_region}")
+    client = Aws::ElasticLoadBalancingV2::Client.new(region: stack_region)
+
+    Chef::Log.info("Registering EC2 instance #{ec2_instance_id} with target group #{target_group_arn}")
+
+    target_to_attach = {
+      target_group_arn: target_group_arn,
+      targets: [{ id: ec2_instance_id }]
+    }
+
+    client.register_targets(target_to_attach)
+  end
+  action :run
+end

--- a/alb_support/recipes/shutdown.rb
+++ b/alb_support/recipes/shutdown.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook:: alb_support
+# Recipe:: shutdown
+#
+# Copyright:: 2020, BackerFounder, All Rights Reserved.
+
+stack = search("aws_opsworks_stack").first
+stack_region = stack[:region]
+instance = search("aws_opsworks_instance", "self:true").first
+ec2_instance_id = instance[:ec2_instance_id]
+
+target_group_arn = node[:alb_support][:target_group_arn]
+connection_draining_timeout = node[:alb_support][:connection_draining_timeout]
+state_check_frequency = node[:alb_support][:state_check_frequency]
+
+ruby_block "detach from ALB" do
+  block do
+    require "aws-sdk-core"
+
+    Chef::Log.info("Creating ELB client in region #{stack_region}")
+    client = Aws::ElasticLoadBalancingV2::Client.new(region: stack_region)
+
+    target_to_detach = {
+      target_group_arn: target_group_arn,
+      targets: [ { id: ec2_instance_id } ],
+    }
+
+    Chef::Log.info("Deregistering EC2 instance #{ec2_instance_id} from Target Group #{target_group_arn}")
+    client.deregister_targets(target_to_detach)
+
+    if connection_draining_timeout == 0
+      Chef::Log.info("connection_draining_timeout was set to 0 seconds. execution of shutdown recipes will not be delayed")
+      return
+    end
+
+    Chef::Log.info("delaying execution recipes until instance is drained from ALB or timeout of #{connection_draining_timeout} seconds elapses")
+    start_time = Time.now
+    loop do
+      response = client.describe_target_health(target_to_detach)
+      target_health_state = response[:target_health_descriptions].first[:target_health][:state]
+      Chef::Log.info("state of instance in ALB: #{target_health_state}")
+      seconds_elapsed = Time.now - start_time
+      Chef::Log.info("#{seconds_elapsed} of a maximum #{connection_draining_timeout} seconds elapsed")
+      Chef::Log.info("Sleeping #{ state_check_frequency} seconds")
+      break if target_health_state == "unused" || seconds_elapsed > connection_draining_timeout
+      sleep(state_check_frequency)
+    end
+  end
+  action :run
+end
+
+

--- a/deploy/recipes/rails.rb
+++ b/deploy/recipes/rails.rb
@@ -13,10 +13,14 @@ app = search(:aws_opsworks_app).first
 app_path = "/srv/www/#{app['shortname']}"
 rds = search(:aws_opsworks_rds_db_instance).first
 
+directory "#{app_path}/tmp" do
+  owner deploy_user
+  group deploy_group
+end
+
 directory "#{app_path}/tmp/cache" do
   owner deploy_user
   group deploy_group
-  recursive true
 end
 
 if node['bundle'] && node['bundle']['config']

--- a/deploy/recipes/setup.rb
+++ b/deploy/recipes/setup.rb
@@ -5,10 +5,14 @@
 # Copyright:: 2020, BackerFounder, All Rights Reserved.
 
 # resync package index
-apt_update 'update'
+apt_update 'update' do
+  action :nothing
+end
 
 # gem `curb` uses libcurl
-apt_package 'libcurl4-gnutls-dev'
+apt_package 'libcurl4-gnutls-dev' do
+  notifies :update, 'apt_update[update]', :before
+end
 
 # gem `pg` uses libpq
 apt_package 'libpq-dev'


### PR DESCRIPTION
* 新增 alb_support cookbook 來把 instance 加進 target group & 移出 target group（大量參考 [opsworks-example-cookbooks](https://github.com/aws-samples/opsworks-example-cookbooks/blob/master/alb_support/recipes/attach_to_alb.rb)）
* 修正 deploy::setup 中 apt_package 和 apt_update 可能同時執行的問題
 
目前的執行順序：
**App 機**
| 階段 | cookbooks |
|-|-|
| setup | deploy_user, deploy::setup, node, node::yarn, ruby, puma::setup, nginx::setup, nginx::puma_config |
| deploy | deploy_user::pass_vars, ruby::pass_vars, deploy, deploy::rails, puma::deploy, nginx::deploy, **alb_support::deploy** |
| shutdown | **alb_support::shutdown** |


**Worker 機**
| 階段 | cookbooks |
|-|-|
| setup | deploy_user, deploy::setup, node, node::yarn, ruby |
| deploy | deploy_user::pass_vars, ruby::pass_vars, deploy, deploy::rails, sidekiq |

目前 PR 的 merge 方向：
 master << next/chef12 << sidekiq_cookbook << alb_support