### PR TITLE
chore: add options to allow static files served by the server

### DIFF
--- a/nginx/templates/nginx_puma.conf.erb
+++ b/nginx/templates/nginx_puma.conf.erb
@@ -56,6 +56,10 @@ server {
            proxy_pass http://puma_<%= app_shortname %>;
   }
 
+  location ~* \.(eot|ttf|woff|woff2)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
+
   # Now this supposedly should work as it gets the filenames with querystrings that Rails provides.
   # BUT there's a chance it could break the ajax calls.
   location ~* \.(ico|css|gif|jpe?g|png|js)(\?[0-9]+)?$ {

--- a/puma/attributes/default.rb
+++ b/puma/attributes/default.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+default[:puma][:serve_static_files] = false

--- a/puma/recipes/setup.rb
+++ b/puma/recipes/setup.rb
@@ -7,6 +7,7 @@
 deploy_user = node.run_state[:deploy_user]
 bundle_path = node.run_state[:bundle_path]
 rails_env = node.run_state[:rails_env]
+serve_static_files = node[:puma][:serve_static_files].to_s.downcase == 'true'
 
 app = search(:aws_opsworks_app).first
 app_path = "/srv/www/#{app['shortname']}"
@@ -17,4 +18,5 @@ template "/etc/systemd/system/puma.service" do
   helper(:bundle_path) { bundle_path }
   helper(:deploy_user) { deploy_user }
   helper(:rails_env) { rails_env }
+  helper(:serve_static_files){ serve_static_files }
 end

--- a/puma/templates/puma.service.erb
+++ b/puma/templates/puma.service.erb
@@ -9,6 +9,9 @@ Type=simple
 User=<%= deploy_user %>
 WorkingDirectory=<%= app_path %>
 Environment=RAILS_ENV=<%= rails_env %>
+<% if serve_static_files %>
+  Environment=RAILS_SERVE_STATIC_FILES=true
+<% end %>
 # ENV['PUMA_BINDING_SOCKET'] is used in config/puma.rb:L1
 Environment=PUMA_BINDING_SOCKET=true
 ExecStart=<%= bundle_path %> exec puma -C <%= app_path %>/config/puma.rb <%= app_path %>/config.ru


### PR DESCRIPTION
* 測試站 (.co, .me) 不是透過 cloudfront 來 serve 取得靜態檔案的，所以會需要把 RAILS_SERVE_STATIC_FILES 的選項加回來。
* 另外兩個測試站共用同一群機器，字型會有跨網域共用的問題，所以加上 `Access-Control-Allow-Origin *;` 的 header