### PR TITLE
feat: nginx cookbook 加上 `client_max_body_size` attribute

### DIFF
--- a/nginx/attributes/default.rb
+++ b/nginx/attributes/default.rb
@@ -2,6 +2,7 @@
 
 default['nginx']['worker_connections'] = '1024'
 default['nginx']['keepalive_timeout'] = 65
+default['nginx']['client_max_body_size'] = '2M'
 default['nginx']['log_dir'] = '/var/log/nginx'
 default['nginx']['gzip_types'] = [
   "application/json",

--- a/nginx/templates/nginx.conf.erb
+++ b/nginx/templates/nginx.conf.erb
@@ -21,6 +21,8 @@ http {
     types_hash_max_size 2048;
     server_tokens off;
 
+    client_max_body_size <%= node['nginx']['client_max_body_size'] %>;
+
     server_names_hash_bucket_size 64;
     server_name_in_redirect off;
 


### PR DESCRIPTION
backme 後台有多圖上傳功能，改成 chef 12 後有客戶反應多圖上傳會遇到 413 Request entity too large 的問題，所以把 client_max_body_size 改成可以用 chef attribute 設定，先將預設值調成 2M。