### PR TITLE
fix: migration rake task attribute

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -23,7 +23,9 @@ DEPENDENCIES
 GRAPH
   alb_support (0.1.0)
   deploy (0.1.0)
+    logrotate (~> 2.3.0)
   deploy_user (0.1.0)
+  logrotate (2.3.0)
   nginx (0.1.0)
   node (0.1.0)
   papertrail (0.1.0)

--- a/deploy/attributes/default.rb
+++ b/deploy/attributes/default.rb
@@ -9,6 +9,9 @@ default['deploy']['db_pool'] = 5
 default['deploy']['db_name'] = ''
 default['deploy']['db_port'] = '5432'
 
+### Migration settings
+default['deploy']['migrate_rake'] = 'db:migrate'
+
 ### Application settings
 default['deploy']['rails_env'] = 'production'
 default['deploy']['application_yml'] = {}

--- a/deploy/recipes/rails.rb
+++ b/deploy/recipes/rails.rb
@@ -67,13 +67,15 @@ file "#{app_path}/config/application.yml" do
   group deploy_group
 end
 
-execute 'Migrate database' do
+
+execute "Migrate database: rake #{node['deploy']['migrate_rake']}" do
   cwd app_path
   user deploy_user
   group deploy_group
-  command "#{bundle_path} exec rake db:migrate"
+  command "#{bundle_path} exec rake #{node['deploy']['migrate_rake']}"
   environment environment 'HOME' => deploy_home, 'RAILS_ENV' => rails_env
 end
+
 
 execute 'Assets precompile' do
   cwd app_path


### PR DESCRIPTION
測試站測試完畢

## 相關 issue
- [Backme#6501](https://github.com/BackerFounder/backme/issues/6501)

## PR 說明
- 加上 attribute `default['deploy']['migrate_rake']` 可以替換掉 db:migrate 的 command 

## 圖示說明
無